### PR TITLE
Some useful changes to fix a small issue, and include basic file logging

### DIFF
--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -618,11 +618,11 @@ def parse_args():
 
     logger = logging.getLogger('wsdd')
 
-    if not args.interface:
-        logger.warning('no interface given, using all interfaces')
-
     if args.logfile:
         print('logging to ' + args.logfile)
+
+    if not args.interface:
+        logger.warning('no interface given, using all interfaces')
 
     if not args.uuid:
         args.uuid = uuid.uuid5(uuid.NAMESPACE_DNS, socket.gethostname())


### PR DESCRIPTION
Changes are self-evident from "preview", and tested on FreeBSD.

**HOSTNAME issue:**

Best shown by example. I don't know if this is something specific to FreeNAS or also a wider issue in FreeBSD or some kinds of situation, but fix it anyway:

```  # python3
Python 3.6.5 (default, Dec 20 2018, 21:27:40)
[GCC 4.2.1 Compatible FreeBSD Clang 6.0.0 (tags/RELEASE_600/final 326565)] on freebsd11
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> print (socket.gethostname())
server2.localnet.lan
>>>
```

Hosts such as Samba on FreeNAS are listed in Windows as their FQDN, which isn't correct. This fixes it. (Although an option to deliberately use FQDN not HOSTNAME might be useful in the rare case you find yourself with 2 hosts with same name but configured as 2 subdomains?)

**Basic Log to file**

Logging to file is needed if daemonised, which is the most likely use. Could be done better (log size limit, system log redirect) but at least it isn't just going to the console, and can be backgrounded neatly. logs don't seem to be huge, even if verbose, by nature of the protocol.