### PR TITLE
Update wsdd.service

### DIFF
--- a/etc/systemd/wsdd.service
+++ b/etc/systemd/wsdd.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/wsdd --shortlog
 ; Replace those with an unprivledged user/group that matches your environment,
 ; like nobody/nogroup or daemon:daemon or a dedicated user for wsdd
 User=nobody
-Group=nobody
+Group=nogroup
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The "Group" parameter should have the value "nogroup" instead of "nobody" since "nobody" is not a valid group by default but "nogroup" is and have the intended purpose.