### PR TITLE
Allow lowercase hostnames

### DIFF
--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -355,7 +355,7 @@ def wsd_handle_get():
     if args.domain:
         ElementTree.SubElement(host, PUB_COMPUTER).text = (
                 '{0}/Domain:{1}'.format(
-                    args.hostname.upper(),
+                    args.hostname,
                     args.domain))
     else:
         ElementTree.SubElement(host, PUB_COMPUTER).text = (


### PR DESCRIPTION
In AD environments, the lowercase hostname can also be used. To give
users a better integration in their existing environments, the hostname
will not be changed to uppercase anymore, if a domain name is set.