### PR TITLE
Fix problem wsdd_group isn't set correctly in FreeBSD rc.d script

### DIFF
--- a/etc/rc.d/wsdd
+++ b/etc/rc.d/wsdd
@@ -9,14 +9,11 @@
 
 name=wsdd
 rcvar=wsdd_enable
-wsdd_group=""
+wsdd_group=$(/usr/local/bin/testparm -s --parameter-name workgroup 2>/dev/null)
 
-if which testparm >/dev/null 2>/dev/null; then
-	wsdd_group=$(testparm -s --parameter-name workgroup 2>/dev/null)
-fi
+: ${wsdd_smb_config_file="/usr/local/etc/smb4.conf"}
 
 # try to manually extract workgroup from samba configuration if testparm failed
-wsdd_smb_config_file="/usr/local/etc/smb.conf"
 if [ -z "$wsdd_group" ] && [ -r $wsdd_smb_config_file ]; then
 	wsdd_group="$(grep -i '^[[:space:]]*workgroup[[:space:]]*=' $wsdd_smb_config_file | cut -f2 -d= | tr -d '[:blank:]')"
 fi


### PR DESCRIPTION
I'm now making FreeBSD port of `wsdd` and found problem `wsdd_group` isn't set correctly when FreeBSD rc.d script is executed at system boot time or by executing `service wsdd start`. By investigation it happens as following.

1. If you install Samba by using FreeBSD port `testparm` is installed in `/usr/local/bin`. But this directory isn't included in `PATH` environment variable when rc.d script is executed at system boot time or by executing `service wsdd start`. Then `which testparm` fails and line 15 of `etc/rc.d/wsdd` isn't executed.
2. If you install Samba by using FreeBSD port default path of configuration file is not`/usr/local/etc/smb.conf` but `/usr/local/etc/smb4.conf`. Moreover it can be changed by setting `samba_server_config` in `/etc/rc.conf`. So line 20 of `etc/rc.d/wsdd` always fails and therefore line 21 is never executed.

So this comit fixes problem as follwing.

1. Stop checking if `testparm` is found in `PATH` directories and simply use absolute path.
2. Make `wsdd_smb_config_file` configurable and set default value to one of Samba port.