### PR TITLE
Support running multiple instances with different names and UUIDs

### DIFF
--- a/etc/openrc/conf.d/wsdd
+++ b/etc/openrc/conf.d/wsdd
@@ -10,6 +10,12 @@
 # Disable automatic detection of the workgroup from samba configuration.
 #WSDD_WORKGROUP="MYGROUP"
 
+# Listen on interface or IP only
+#WSDD_INTERFACE="192.168.0.1"
+
+# Announce this name instead of hostname
+#WSDD_HOST="ADAMS"
+
 # Additional options for the daemon, e.g. to listen on interface eth0 only.
 # Refer to wsdd(1) for details.
 #WSDD_OPTS="-i eth0"

--- a/etc/openrc/init.d/wsdd
+++ b/etc/openrc/init.d/wsdd
@@ -12,6 +12,10 @@ LOG_FILE="${WSDD_LOG_FILE:-/var/log/wsdd.log}"
 WSDD_EXEC="/usr/bin/wsdd"
 RUN_AS_USER="${WSDD_USER:-daemon:daemon}"
 
+SVCPREFIX="${SVCNAME%.*}"
+INSTNAME="${SVCNAME:${#SVCPREFIX}+1}"
+
+
 start() {
 	ebegin "Starting ${RC_SVCNAME} daemon"
 
@@ -32,7 +36,29 @@ start() {
 			OPTS="-w ${GROUP} ${OPTS}"
 		fi
 	else
-		OPTS="-w ${WSDD_WORKGROUP} ${OPTS}"
+		OPTS="-w ${WSDD_WORKGROUP} ${OPTS}"	
+	fi
+
+	if [ -z "${WSDD_HOST}" ]; then
+		WSDD_HOST="${INSTNAME}"
+	fi
+
+	if [ -n "${WSDD_HOST}" ]; then
+		OPTS="-n ${WSDD_HOST} ${OPTS}"	
+	fi
+
+	if [ -n "${WSDD_INTERFACE}" ]; then
+		OPTS="-i ${WSDD_INTERFACE} ${OPTS}"	
+	fi
+
+	if [ -n "${INSTNAME}" ]; then
+		if ! [[ "${OPTS}" =~ -i ]] && ! [[ "${OPTS}" =~ --interface ]]; then
+			ewarn "If running multiple service-instances set WSDD_INTERFACE or parameter -i"
+		fi
+		if [ -f "/etc/conf.d/${SVCPREFIX}" ]; then
+			# May lead to unexpected behavior because of inhertitance, show config"
+			einfo "Using hostname ${WSDD_HOST} on ${WSDD_INTERFACE}"
+		fi
 	fi
 
 	if [ ! -r "${LOG_FILE}" ]; then

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1505,7 +1505,11 @@ def parse_args():
         logger.warning('no interface given, using all interfaces')
 
     if not args.uuid:
-        args.uuid = uuid.uuid5(uuid.NAMESPACE_DNS, socket.gethostname())
+        if args.hostname:
+            hn = '{0}.{1}'.format(args.hostname, args.workgroup)
+        if not hn:
+            hn=socket.gethostname()
+        args.uuid = uuid.uuid5(uuid.NAMESPACE_DNS, hn)
         logger.info('using pre-defined UUID {0}'.format(str(args.uuid)))
     else:
         args.uuid = uuid.UUID(args.uuid)


### PR DESCRIPTION
Those changes will allow to run multiple instances of the service.

wsdd.py: Changed the generation of the UUID to use the hostname provided 
on the commandline, if set, so each instance has their own UUID

The changes to the Gentoo-init-scripts are provided to make life bit easier and prevent
mistakes.