### PR TITLE
Use DynamicUser=yes instead of nobody/nobody in systemd unit file

### DIFF
--- a/etc/systemd/wsdd.service
+++ b/etc/systemd/wsdd.service
@@ -9,10 +9,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/wsdd --shortlog
-; Replace those with an unprivledged user/group that matches your environment,
-; like nobody/nogroup or daemon:daemon or a dedicated user for wsdd
-User=nobody
-Group=nobody
+DynamicUser=yes
 ; The following lines can be used for a chroot execution of wsdd.
 ; Also append '--chroot /run/wsdd/chroot' to ExecStart to enable chrooting
 ;AmbientCapabilities=CAP_SYS_CHROOT


### PR DESCRIPTION
Use `DynamicUser=yes` instead of `nobody/nobody` to prevent the systemd warning message: `Special user nobody configured, this is not safe!`

`DynamicUser` has been introduced with systemd 235, so nearly every system should be able to understand this systemd option nowadays. See http://0pointer.net/blog/dynamic-users-with-systemd.html for detailed explanation.

Signed-off-by: Volker Theile <votdev@gmx.de>
