### PR TITLE
Making the script work on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - GitHub workflow for static analyses added (syntax, format, and type checks are performed).
 - Added EnvironmentFile and according example for systemd-based distros.
+- Make wsdd work (again) on MacOS (#139). Thanks to Eugene Gershnik.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Samba at some time in the future.
 
 # Requirements
 
-wsdd requires Python 3.7 and later only. It runs on Linux and FreeBSD. Other Unixes, such
+wsdd requires Python 3.7 and later only. It runs on Linux, FreeBSD and MacOS. Other Unixes, such
 as OpenBSD or NetBSD, might work as well but were not tested.
 
 Although Samba is not strictly required by wsdd itself, it makes sense to run

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1590,8 +1590,9 @@ class RouteSocketAddressMonitor(NetworkAddressMonitor):
     IF_DATA_DEFS: Dict[str, str] = {
         # if_data in if_msghdr is prepended with an u_short _ifm_spare1, thus the 'H' a the beginning)
         'FreeBSD': 'H6c2c8c8c104c8c16c',
-        # There are 21 uint32_t in the if_data struct (21 x 4 Bytes = (12 + 72) x 1 Bytes = 84 Bytes)
-        'Darwin': '8c12c72c'
+        # There are 8 bytes and 22 uint32_t in the if_data struct (22 x 4 Bytes + 8 = 96 Bytes)
+        # It is also aligned on 4-byte boundary necessitating 2 bytes padding inside if_msghdr
+        'Darwin': '2c8c22I'
     }
 
     socket: socket.socket

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1644,7 +1644,7 @@ class RouteSocketAddressMonitor(NetworkAddressMonitor):
                 # sizeof(if_msghdr) == 112, sizeof(ifa_msghdr) == 20 on Darwin
                 sa_offset = offset + (112 if rtm_type == self.RTM_IFINFO else 20)
             else:
-                raise NotImplementedError('unknown offest for OS: ' + self.system)
+                raise NotImplementedError('unknown offset for OS: ' + self.system)
 
             # For a route socket message, and different to a sysctl response,
             # the link info is stored inside the same rtm message, so it has to

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1567,7 +1567,7 @@ IN6_IFF_TENTATIVE: int = 0x02
 IN6_IFF_DUPLICATED: int = 0x04
 IN6_IFF_NOTREADY: int = IN6_IFF_TENTATIVE | IN6_IFF_DUPLICATED
 
-SA_ALIGNTO: int = ctypes.sizeof(ctypes.c_long)
+SA_ALIGNTO: int = ctypes.sizeof(ctypes.c_long) if platform.system() != "Darwin" else ctypes.sizeof(ctypes.c_uint32)
 
 
 class RouteSocketAddressMonitor(NetworkAddressMonitor):

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1640,7 +1640,7 @@ class RouteSocketAddressMonitor(NetworkAddressMonitor):
         intf_flags = 0
         while offset < len(buf):
             # unpack route message response
-            rtm_len, _, rtm_type, addr_mask, flags = struct.unpack_from(self.RTM_HDR_DEF, buf, offset)
+            rtm_len, _, rtm_type, addr_mask, flags = struct.unpack_from(self.IF_COMMON_HDR_DEF, buf, offset)
 
             if rtm_type not in [self.RTM_NEWADDR, self.RTM_DELADDR, self.RTM_IFINFO]:
                 offset += rtm_len

--- a/test/routesocket_monitor.py
+++ b/test/routesocket_monitor.py
@@ -34,9 +34,9 @@ def parse_route_socket_response(buf, keep_link):
     link = None
     print(len(buf))
     while offset < len(buf):
-        rtm_len, _, rtm_type = struct.unpack_from('@HBB', buf, offset)
         # mask(addrs) has same offset in if_msghdr and ifs_msghdr
-        addr_mask, flags = struct.unpack_from('ii', buf, offset + 4)
+        rtm_len, _, rtm_type, addr_mask, flags = struct.unpack_from(
+            '@HBBii', buf, offset)
 
         msg_type = ''
         if rtm_type not in [RTM_NEWADDR, RTM_DELADDR, RTM_IFINFO]:
@@ -44,6 +44,7 @@ def parse_route_socket_response(buf, keep_link):
             continue
 
         # those offset may unfortunately be architecture dependent
+        # (152 is FreeBSD-specific)
         sa_offset = offset + ((16 + 152) if rtm_type == RTM_IFINFO else 20)
 
         if rtm_type in [RTM_NEWADDR, RTM_IFINFO]:


### PR DESCRIPTION
FreeBSD code path works just fine on Mac. The only changes necessary were:

* Recognize 'Darwin' as a supported platform and direct the code to use `RouteSocketAddressMonitor`
* Use system specific sizes of routing table headers. One of these isn't the same on MacOS as is on FreeBSD.
* Fix a small bug in handling of `intf_blacklist` (this probably happens on FreeBSD too but I don't have one to check).