### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,34 @@ can install wsdd like on Fedora where it is sufficient to issue
 
 `dnf install wsdd`
 
-### Debian/Ubuntu
+### Debian/Ubuntu/Mint
 
-There are user-maintained packages for which you need to add the repository to
-```/etc/apt/sources.list.d``` with a file containing the following line
+There are user-maintained packages which you can install by following these steps:
 
-`deb https://pkg.ltec.ch/public/ distro main`
+1. import the security key for that repository
+```
+sudo apt-key adv --fetch-keys https://pkg.ltec.ch/public/conf/ltec-ag.gpg.key
+```
 
-Replace `distro` with the name of your distro, e.g. `buster` or `xenial` (issue
-`lsb_release -cs` if unsure). After an `apt update` you can install wsdd with
-`apt install wsdd`.
+2. find out your distro, which is the codename for your version of debian. Debian uses codenames for various versions such as `buster` or `bullseye`. If you are unsure what your distro is you can find out in debian by using
+```
+lsb_release -cs
+```
+In Ubuntu or Mint, if you are using an up to date version, you will just want to use the latest version.
+Go to https://www.debian.org/download to locate the latest codename for debian.
+You can double check that this codename appears here https://pkg.ltec.ch/public/dists/ and if it does not find the latest codename that does.
 
-You also need to import the public key of the repository like this `apt-key adv --fetch-keys https://pkg.ltec.ch/public/conf/ltec-ag.gpg.key`.
+3. add the repository to `/etc/apt/sources.list.d` with a file containing the following line `deb https://pkg.ltec.ch/public/ DISTRO main` replacing `DISTRO` with the codename of your Debian distro.
+
+4. refresh available packages via
+```
+apt update
+```
+
+5. install wsdd via
+```
+apt install wsdd
+```
 
 ### Gentoo
 
@@ -80,8 +96,14 @@ one of them you can install wsdd with
 
 ```
 emerge eselect-repository
+```
+```
 eselect repository enable guru
+```
+```
 emerge --sync
+```
+```
 emerge wsdd
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ In Ubuntu or Mint, if you are using an up to date version, you will just want to
 Go to https://www.debian.org/download to locate the latest codename for debian.
 You can double check that this codename appears here https://pkg.ltec.ch/public/dists/ and if it does not find the latest codename that does.
 
+Debian 11.4 Bullseye is the latest version for Mint 20 and Ubuntu 22.
+
 3. add the repository to `/etc/apt/sources.list.d` with a file containing the following line `deb https://pkg.ltec.ch/public/ DISTRO main` replacing `DISTRO` with the codename of your Debian distro.
+
+in mint you can do this via GUI: `menu > administration > software sources > additional repositories > add`
 
 4. refresh available packages via
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ can install wsdd like on Fedora where it is sufficient to issue
 ### Debian/Ubuntu
 
 There are user-maintained packages for which you need to add the repository to
-`/etc/apt/sources.list.d` with a file containing the following line
+```/etc/apt/sources.list.d``` with a file containing the following line
 
 `deb https://pkg.ltec.ch/public/ distro main`
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Install wsdd from the [AUR package](https://aur.archlinux.org/wsdd.git).
 wsdd is included in RedHat/CentOS' EPEL repository. After setting that up, you
 can install wsdd like on Fedora where it is sufficient to issue
 
-`dnf install wsdd`
+```
+dnf install wsdd
+```
 
 ### Debian/Ubuntu/Mint
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ In Ubuntu or Mint, if you are using an up to date version, you will just want to
 Go to https://www.debian.org/download to locate the latest codename for debian.
 You can double check that this codename appears here https://pkg.ltec.ch/public/dists/ and if it does not find the latest codename that does.
 
-Debian 11.4 Bullseye is the latest version for Mint 20 and Ubuntu 22.
-
 3. add the repository to `/etc/apt/sources.list.d` with a file containing the following line `deb https://pkg.ltec.ch/public/ DISTRO main` replacing `DISTRO` with the codename of your Debian distro.
 
 in mint you can do this via GUI: `menu > administration > software sources > additional repositories > add`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ apt update
 apt install wsdd
 ```
 
+6. optionally you can configure wsdd via changing `/etc/wsdd.conf`.
+
+7. run wsdd via
+```
+sudo systemctl start wsdd
+```
+
 ### Gentoo
 
 You can choose between two overlays: the GURU project and an [author-maintained


### PR DESCRIPTION
* corrected github notation for terminal commands to produce a button that will copy commands with a click
* split gentoo instructions so that they are copied one by one instead of all at once
* added sudo where appropriate to ubuntu install
* clarified debian/ubuntu instructions
* debian/ubuntu should import the key before adding the repo rather than after.
* added mint instructions (it is the same as ubuntu)
