### PR TITLE
feat(src): Allow listing devices of concrete types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Configuration files for firewalld (#186). Thanks to Ondrej Holy.
+- Show device type and allow filtering in API's `list` command (#189). Thanks to Ondrej Holy.
 
 ### Changed
 

--- a/man/wsdd.8
+++ b/man/wsdd.8
@@ -164,10 +164,12 @@ only. The following commands can be issued:
 Clears the list of all discovered devices. Use the \fBprobe\fR command to
 search for devices again. This command does not return any data and is only
 available in discover mode.
-.SS \fBlist\fR - List discovered devices
-Returns a tab-separated list of discovered devices with the following information.
-The possibly empty list of detected hosts is always terminated with a single
-dot ('.') in an otherwise empty line. This command is only available in discover mode.
+.SS \fBlist \fI[TYPE]\fR - List discovered devices
+Returns a tab-separated list of discovered devices of the provided TYPE (e.g.
+"pub:Computer") with the following information. If no type is provided, all
+discovered devices are listed. The possibly empty list of detected hosts is
+always terminated with a single dot ('.') in an otherwise empty line. This
+command is only available in discover mode.
 .TP
 UUID
 UUID of the discovered device. Note that a multi-homed device should appear

--- a/man/wsdd.8
+++ b/man/wsdd.8
@@ -194,6 +194,9 @@ process delimited by commas.  Addresses are provided along with the interface
 (separated by '%') on which they were discovered.  IPv6 addresses are reported
 on square brackets. Note that the reported addresses may not match the actual
 device on which the device may be reached.
+.TP
+types
+Types of the detected device, delimited by commas.
 .SS \fBprobe \fI[INTERFACE]\fR - Search for devices
 Triggers a Probe message on the provided INTERFACE (eth0, e.g.) to search for
 WSD hosts. If no interface is provided, all interfaces wsdd listens on are probed.

--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -1187,12 +1187,13 @@ class ApiServer:
             for addrs in dev.addresses.items():
                 addrs_str.append(', '.join(['{}'.format(a) for a in addrs]))
 
-            retval = retval + '{}\t{}\t{}\t{}\t{}\n'.format(
+            retval = retval + '{}\t{}\t{}\t{}\t{}\t{}\n'.format(
                 dev_uuid,
                 dev.display_name,
                 dev.props['BelongsTo'] if 'BelongsTo' in dev.props else '',
                 datetime.datetime.fromtimestamp(dev.last_seen).isoformat('T', 'seconds'),
-                ','.join(addrs_str))
+                ','.join(addrs_str),
+                ','.join(dev.types))
 
         retval += '.\n'
         return retval


### PR DESCRIPTION
Currently, the "list" command returns all discovered devices. This includes also devices without host services like printers. That is a problem for some API clients (i.e. gvfs). Let's add an optional argument to specify concrete type.

Fixes: https://github.com/christgau/wsdd/issues/178