### PR TITLE
Always test against the system version of python3

### DIFF
--- a/test/regressions/01_asyncio_changes_python310/run_tcp.sh
+++ b/test/regressions/01_asyncio_changes_python310/run_tcp.sh
@@ -4,7 +4,7 @@
 # The API for ´start_server´ was schanged in 3.10.
 # @see related Github issue #162
 
-python_versions=('3.7' '3.8' '3.9.' '3.10' '3.11')
+python_versions=('3' '3.7' '3.8' '3.9.' '3.10' '3.11')
 
 socket_port="3333"
 

--- a/test/regressions/01_asyncio_changes_python310/run_unix.sh
+++ b/test/regressions/01_asyncio_changes_python310/run_unix.sh
@@ -4,7 +4,7 @@
 # The API for ´start_unix_server´ was schanged in 3.10.
 # @see Github issue #162
 
-python_versions=('3.7' '3.8' '3.9.' '3.10' '3.11')
+python_versions=('3' '3.7' '3.8' '3.9.' '3.10' '3.11')
 
 socket_dir="$(mktemp -d)"
 socket_filename="${socket_dir}/wsdd.sock"


### PR DESCRIPTION
The list is good for testing against multiple versions, but gets out-of-date whenever a new version of python3 is released.

To enable testing in downstream packaging, make sure to always test against the system installed version of python3 at least.