### PR TITLE
Address xml deprecation working

### DIFF
--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -646,7 +646,7 @@ class WSDDiscoveredDevice:
             elif dialect == WSDP_URI + '/Relationship':
                 host_xpath = 'wsdp:Relationship[@Type="{}/host"]/wsdp:Host'.format(WSDP_URI)
                 host_sec = section.find(host_xpath, namespaces)
-                if (host_sec):
+                if (host_sec is not None):
                     self.extract_host_props(host_sec)
             else:
                 logger.debug('unknown metadata dialect ({})'.format(dialect))


### PR DESCRIPTION
DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if (host_sec):