### PR TITLE
fix(src): Close connections to API clients when shutting down

### DIFF
--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -871,6 +871,8 @@ class WSDClient(WSDUDPMessageHandler):
                 self.handle_metadata(stream.read(), endpoint, xaddr)
         except urllib.error.URLError as e:
             logger.warning('could not fetch metadata from: {} {}'.format(url, e))
+        except TimeoutError:
+            logger.warning('metadata exchange with {} timed out'.format(url))
 
     def build_getmetadata_message(self, endpoint) -> str:
         tree, _ = self.build_message_tree(endpoint, WSD_GET, None, None)


### PR DESCRIPTION
This effectively re-implements `asyncio.Server::close_clients` which is only available in python3.13.

In python3.12 `asyncio.Server::wait_closed` will hang unless these sockets are closed: https://github.com/python/cpython/issues/104344