### PR TITLE
add SunOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add command line argument to set source port for multicast message for better firewall interoperability (#216)
+- Add initial support for SunOS (#223), without dynamic address/interface monitoring. Thanks to Carsten Grzemba.
 
 ### Changed
 


### PR DESCRIPTION
This adds basic SunOS support tested on Illumos. Currently the NetworkAddressMonitor do not do dynamic network interface updates. The SMF manifest is not contained.