### PR TITLE
Make --chroot and --discovery work at the same time

### DIFF
--- a/src/wsdd.py
+++ b/src/wsdd.py
@@ -2013,6 +2013,11 @@ def chroot(root: str) -> bool:
     """
     # preload for socket.gethostbyaddr()
     import encodings.idna
+    import shutil
+    os.makedirs(root + '/etc/', exist_ok=True)
+    shutil.copy('/etc/resolv.conf',root + '/etc/')
+    # for listen
+    import concurrent.futures.thread
 
     try:
         os.chroot(root)


### PR DESCRIPTION
The discovery thread had errors when running under chroot. Tested on Ubuntu/jammy/22.04 and Ubuntu/noble/24.04