### PR TITLE
Fix: Honor --ipv4only/--ipv6only settings during interface iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Fixed
+
+- Address filtering during interface enumeration respects command line options more strict (see #238)
+
 ## [0.9] -- 2025-06-01
 
 ### Added


### PR DESCRIPTION
Properly filter network interfaces based on --ipv4only and --ipv6only settings to avoid errors with unsupported families (e.g., AF_INET6).